### PR TITLE
fix(auth): buffer subsequent requests

### DIFF
--- a/lib/ksks.js
+++ b/lib/ksks.js
@@ -2,6 +2,7 @@
 
 var cacheManager = require('cache-manager'),
   client = require('simple-keystone-client'),
+  PiggybackBuffer = require('piggyback-buffer'),
   _ = require('underscore');
 
 var DAYS_TO_SECONDS = 60 * 60 * 24;
@@ -14,8 +15,10 @@ function isExpired(catalog) {
 
 function ksks(options) {
   var options_ = options || {},
+    buffer,
     cache;
 
+  buffer = new PiggybackBuffer();
   cache = options_.cache || cacheManager.caching({ store: 'memory' });
 
   return {
@@ -31,18 +34,27 @@ function ksks(options) {
           }
         }
 
-        client.authenticate(_.extend(
-          _.pick(options_, 'identityEndpoint'),
-          _.pick(props, 'username', 'password', 'apiKey', 'tenantId')),
-          function (err, res) {
-            if (err) {
-              return cb(err);
+        if (buffer.isPending(key)) {
+          buffer.queue(key, cb);
+        } else {
+          buffer.queue(key, cb);
+          client.authenticate(_.extend(
+            _.pick(options_, 'identityEndpoint'),
+            _.pick(props, 'username', 'password', 'apiKey', 'tenantId')),
+            function (err, res) {
+              if (err) {
+                return buffer.reject(key, err);
+              }
+              cache.set(key, res, 1 * DAYS_TO_SECONDS, function (err) {
+                if (err) {
+                  buffer.reject(key, err);
+                } else {
+                  buffer.resolve(key, res);
+                }
+              });
             }
-            cache.set(key, res, 1 * DAYS_TO_SECONDS, function (err) {
-              cb(err || null, res);
-            });
-          }
-        );
+          );
+        }
       });
     }
   };

--- a/package.json
+++ b/package.json
@@ -27,8 +27,9 @@
   },
   "homepage": "https://github.com/ksheedlo/ksks",
   "dependencies": {
-    "simple-keystone-client": "^1.0.0",
     "cache-manager": "^0.16.0",
+    "piggyback-buffer": "^1.0.0",
+    "simple-keystone-client": "^1.0.0",
     "underscore": "^1.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Using a PiggybackBuffer, we allow subsequent requests for auth before
the credentials reach the cache to be fulfilled by the existing request.
